### PR TITLE
[B] bugfix : 지연로딩 관련 개념 학습 후 적용

### DIFF
--- a/backend/src/main/java/ssu/groupstudy/domain/notice/domain/CheckNotice.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/notice/domain/CheckNotice.java
@@ -34,14 +34,15 @@ public class CheckNotice {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o)
+    public boolean equals(Object o) {
+        if (this == o){
             return true;
-        if(!(o instanceof CheckNotice)){
+        }
+        if (!(o instanceof CheckNotice)) {
             return false;
         }
-        final CheckNotice that = (CheckNotice) o;
-        return Objects.equals(notice.getNoticeId(), that.notice.getNoticeId()) && Objects.equals(user.getUserId(), that.user.getUserId());
+        CheckNotice that = (CheckNotice) o;
+        return Objects.equals(this.notice.getNoticeId(), that.notice.getNoticeId()) && Objects.equals(this.user.getUserId(), that.user.getUserId());
     }
 
     @Override

--- a/backend/src/main/java/ssu/groupstudy/domain/notice/domain/CheckNotice.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/notice/domain/CheckNotice.java
@@ -37,9 +37,9 @@ public class CheckNotice {
     public boolean equals(final Object o) {
         if (this == o)
             return true;
-        if (o == null || getClass() != o.getClass())
+        if(!(o instanceof CheckNotice)){
             return false;
-
+        }
         final CheckNotice that = (CheckNotice) o;
         return Objects.equals(notice.getNoticeId(), that.notice.getNoticeId()) && Objects.equals(user.getUserId(), that.user.getUserId());
     }

--- a/backend/src/main/java/ssu/groupstudy/domain/notice/domain/Notice.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/notice/domain/Notice.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.FetchType.EAGER;
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
@@ -44,7 +43,7 @@ public class Notice extends BaseEntity {
     @JoinColumn(name = "userId", nullable = false)
     private User writer;
 
-    @ManyToOne(fetch = EAGER) // FIXME : EAGER 필수 (this.study issue 관련)
+    @ManyToOne(fetch = LAZY) // FIXME : EAGER 필수 (this.study issue 관련)
     @JoinColumn(name = "studyId", nullable = false)
     private Study study;
 

--- a/backend/src/main/java/ssu/groupstudy/domain/notice/domain/Notice.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/notice/domain/Notice.java
@@ -49,7 +49,7 @@ public class Notice extends BaseEntity {
     private Study study;
 
     @OneToMany(mappedBy = "notice", cascade = ALL, orphanRemoval = true)
-    private Set<CheckNotice> checkNotices = new HashSet<>();
+    private final Set<CheckNotice> checkNotices = new HashSet<>();
 
     @Builder
     public Notice(String title, String contents, User writer, Study study) {

--- a/backend/src/main/java/ssu/groupstudy/domain/round/domain/Round.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/round/domain/Round.java
@@ -35,7 +35,7 @@ public class Round extends BaseEntity {
     private Appointment appointment;
 
     @OneToMany(mappedBy = "round", cascade = PERSIST)
-    private List<RoundParticipant> roundParticipants = new ArrayList<>();
+    private final List<RoundParticipant> roundParticipants = new ArrayList<>();
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name="studyId", nullable = false)
@@ -56,7 +56,7 @@ public class Round extends BaseEntity {
         this.appointment = appointment;
     }
 
-    private void addParticipants(Set<Participant> participants){
+    private void addParticipants(List<Participant> participants){
         participants.stream()
                 .map(participant -> new RoundParticipant(participant.getUser(), this))
                 .forEach(roundParticipants::add);

--- a/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
@@ -26,11 +26,11 @@ public class RoundParticipant {
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name="userId", nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name="roundId", nullable = false)
+    @JoinColumn(name = "roundId", nullable = false)
     private Round round;
 
     @Enumerated(EnumType.STRING)
@@ -40,7 +40,7 @@ public class RoundParticipant {
     @OneToMany(mappedBy = "roundParticipant", cascade = ALL, orphanRemoval = true)
     private Set<Task> tasks = new HashSet<>();
 
-    public RoundParticipant(User user, Round round){
+    public RoundParticipant(User user, Round round) {
         this.user = user;
         this.round = round;
         this.statusTag = StatusTag.NONE;
@@ -48,23 +48,27 @@ public class RoundParticipant {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RoundParticipant roundParticipant = (RoundParticipant) o;
-        return Objects.equals(user, roundParticipant.user) && Objects.equals(round, roundParticipant.round);
-//        return Objects.equals(user.getUserId(), roundParticipant.user.getUserId()) && Objects.equals(round.getRoundId(), roundParticipant.round.getRoundId());
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RoundParticipant)) {
+            return false;
+        }
+
+        RoundParticipant that = (RoundParticipant) o;
+        return Objects.equals(this.user.getUserId(), that.user.getUserId()) && Objects.equals(this.round.getRoundId(), that.round.getRoundId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(user, round);
+        return Objects.hash(user.getUserId(), round.getRoundId());
     }
 
-    public void updateStatus(StatusTag statusTag){
+    public void updateStatus(StatusTag statusTag) {
         this.statusTag = statusTag;
     }
 
-    public Task createTask(String detail, TaskType type){
+    public Task createTask(String detail, TaskType type) {
         Task task = Task.of(detail, type, this);
         tasks.add(task);
         return task;

--- a/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
@@ -54,7 +54,6 @@ public class RoundParticipant {
         if (!(o instanceof RoundParticipant)) {
             return false;
         }
-
         RoundParticipant that = (RoundParticipant) o;
         return Objects.equals(this.user.getUserId(), that.user.getUserId()) && Objects.equals(this.round.getRoundId(), that.round.getRoundId());
     }

--- a/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/round/domain/RoundParticipant.java
@@ -38,7 +38,7 @@ public class RoundParticipant {
     private StatusTag statusTag;
 
     @OneToMany(mappedBy = "roundParticipant", cascade = ALL, orphanRemoval = true)
-    private Set<Task> tasks = new HashSet<>();
+    private final Set<Task> tasks = new HashSet<>();
 
     public RoundParticipant(User user, Round round) {
         this.user = user;

--- a/backend/src/main/java/ssu/groupstudy/domain/study/domain/Participant.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/domain/Participant.java
@@ -50,9 +50,11 @@ public class Participant extends BaseEntity {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof Participant)) {
+            return false;
+        }
         Participant that = (Participant) o;
-        return Objects.equals(user.getUserId(), that.user.getUserId()) && Objects.equals(study.getStudyId(), that.study.getStudyId());
+        return Objects.equals(this.user.getUserId(), that.user.getUserId()) && Objects.equals(this.study.getStudyId(), that.study.getStudyId());
     }
 
     @Override
@@ -65,14 +67,14 @@ public class Participant extends BaseEntity {
         return "0x00";
     }
 
-    public void setColor(String color){
+    public void setColor(String color) {
         validateHex(color);
         this.color = color;
     }
 
     private void validateHex(String color) {
         boolean isHex = color.matches("^(0[xX])?[0-9a-fA-F]+$");
-        if(!isHex){
+        if (!isHex) {
             throw new InvalidColorException(ResultCode.INVALID_COLOR);
         }
     }

--- a/backend/src/main/java/ssu/groupstudy/domain/study/domain/Participants.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/domain/Participants.java
@@ -4,12 +4,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.groupstudy.domain.user.domain.User;
 
-import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
-import static javax.persistence.CascadeType.*;
-import static javax.persistence.FetchType.*;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.FetchType.LAZY;
 
 @Embeddable
 @NoArgsConstructor
@@ -20,7 +23,7 @@ public class Participants {
     private User hostUser;
 
     @OneToMany(mappedBy = "study", cascade = PERSIST, orphanRemoval = true)
-    private Set<Participant> participants = new HashSet<>();
+    private final List<Participant> participants = new ArrayList<>();
 
     public static Participants empty(Participant participant) {
         return new Participants(participant);

--- a/backend/src/main/java/ssu/groupstudy/domain/study/domain/Study.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/domain/Study.java
@@ -12,7 +12,7 @@ import ssu.groupstudy.global.constant.ResultCode;
 import ssu.groupstudy.global.domain.BaseEntity;
 
 import javax.persistence.*;
-import java.util.Set;
+import java.util.List;
 
 import static ssu.groupstudy.domain.study.domain.InviteCode.generate;
 
@@ -77,7 +77,7 @@ public class Study extends BaseEntity {
         return participants.isHostUser(user);
     }
 
-    public Set<Participant> getParticipants(){
+    public List<Participant> getParticipants(){
         return this.participants.getParticipants();
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/domain/task/domain/Task.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/task/domain/Task.java
@@ -9,7 +9,7 @@ import ssu.groupstudy.domain.round.exception.InvalidRoundParticipantException;
 
 import javax.persistence.*;
 
-import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 import static ssu.groupstudy.global.constant.ResultCode.INVALID_TASK_ACCESS;
 
 @Entity
@@ -32,7 +32,7 @@ public class Task{
     @Column(nullable = false)
     private char doneYn;
 
-    @ManyToOne(fetch = EAGER) // TODO : EAGER로 하지 않으면 equals&hash 안먹음
+    @ManyToOne(fetch = LAZY) // TODO : EAGER로 하지 않으면 equals&hash 안먹음
     @JoinColumn(name="user_round_id", nullable = false)
     private RoundParticipant roundParticipant;
 

--- a/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
@@ -1,6 +1,9 @@
 package ssu.groupstudy.domain.user.domain;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import ssu.groupstudy.global.domain.BaseEntity;
 
 import javax.persistence.*;
@@ -10,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static javax.persistence.CascadeType.PERSIST;
-import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 
 
 @Entity
@@ -37,7 +40,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @OneToMany(mappedBy = "user", fetch = EAGER, cascade = PERSIST)
+    @OneToMany(mappedBy = "user", fetch = LAZY, cascade = PERSIST)
     private final List<Authority> roles = new ArrayList<>();
 
     @Column

--- a/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
@@ -67,15 +67,19 @@ public class User extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        User user = (User) o;
-        return Objects.equals(userId, user.userId);
+        if (this == o){
+            return true;
+        }
+        if(!(o instanceof User)){
+            return false;
+        }
+        User that = (User) o;
+        return Objects.equals(this.userId, that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.userId);
     }
 
     @Override

--- a/backend/src/main/java/ssu/groupstudy/global/config/OpenEntityManagerConfig.java
+++ b/backend/src/main/java/ssu/groupstudy/global/config/OpenEntityManagerConfig.java
@@ -1,0 +1,17 @@
+package ssu.groupstudy.global.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+
+@Configuration
+public class OpenEntityManagerConfig {
+    @Bean
+    public FilterRegistrationBean<OpenEntityManagerInViewFilter> openEntityManagerInViewFilter() {
+        FilterRegistrationBean<OpenEntityManagerInViewFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        filterFilterRegistrationBean.setFilter(new OpenEntityManagerInViewFilter());
+        filterFilterRegistrationBean.setOrder(Integer.MIN_VALUE);
+        return filterFilterRegistrationBean;
+    }
+}

--- a/backend/src/main/java/ssu/groupstudy/global/config/OpenEntityManagerConfig.java
+++ b/backend/src/main/java/ssu/groupstudy/global/config/OpenEntityManagerConfig.java
@@ -9,9 +9,9 @@ import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
 public class OpenEntityManagerConfig {
     @Bean
     public FilterRegistrationBean<OpenEntityManagerInViewFilter> openEntityManagerInViewFilter() {
-        FilterRegistrationBean<OpenEntityManagerInViewFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
-        filterFilterRegistrationBean.setFilter(new OpenEntityManagerInViewFilter());
-        filterFilterRegistrationBean.setOrder(Integer.MIN_VALUE);
-        return filterFilterRegistrationBean;
+        FilterRegistrationBean<OpenEntityManagerInViewFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new OpenEntityManagerInViewFilter());
+        bean.setOrder(Integer.MIN_VALUE);
+        return bean;
     }
 }

--- a/backend/src/test/java/ssu/groupstudy/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/comment/service/CommentServiceTest.java
@@ -55,7 +55,6 @@ class CommentServiceTest extends ServiceTest {
             // given
             doReturn(Optional.of(공지사항1)).when(noticeRepository).findByNoticeId(any(Long.class));
             doReturn(댓글1).when(commentRepository).save(any(Comment.class));
-            알고리즘스터디.invite(최규현);
 
             // when
             Long commentId = commentService.createComment(댓글1CreateRequest, 최규현);

--- a/backend/src/test/java/ssu/groupstudy/domain/notice/repository/CheckNoticeRepositoryTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/notice/repository/CheckNoticeRepositoryTest.java
@@ -1,0 +1,32 @@
+package ssu.groupstudy.domain.notice.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import ssu.groupstudy.domain.common.CustomRepositoryTest;
+import ssu.groupstudy.domain.notice.domain.CheckNotice;
+import ssu.groupstudy.domain.user.domain.User;
+
+@CustomRepositoryTest
+class CheckNoticeRepositoryTest {
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+    @Autowired
+    private CheckNoticeRepository checkNoticeRepository;
+
+    @Test
+    @DisplayName("지연 로딩 테스트")
+    void equalsAndHashTest(){
+        // given
+        CheckNotice 최규현꺼 = checkNoticeRepository.findById(1L).get();
+
+        // when
+        User 최규현Proxy = 최규현꺼.getUser();
+        User 최규현Proxy_2 = 최규현꺼.getUser();
+
+        // then
+        softly.assertThat(최규현Proxy).isEqualTo(최규현Proxy_2);
+    }
+}

--- a/backend/src/test/java/ssu/groupstudy/domain/study/service/StudyInviteServiceTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/study/service/StudyInviteServiceTest.java
@@ -51,7 +51,7 @@ class StudyInviteServiceTest extends ServiceTest {
             // given
             // when
             doReturn(Optional.of(알고리즘스터디)).when(studyRepository).findById(any(Long.class));
-            알고리즘스터디.invite(최규현);
+            알고리즘스터디.invite(장재우);
 
             // then
             assertThatThrownBy(() -> studyInviteService.inviteUser(최규현, -1L))
@@ -66,13 +66,12 @@ class StudyInviteServiceTest extends ServiceTest {
             doReturn(Optional.of(알고리즘스터디)).when(studyRepository).findById(any(Long.class));
 
             // when
-            studyInviteService.inviteUser(최규현, -1L);
+            studyInviteService.inviteUser(장재우, -1L);
 
             // then
-            assertAll(
-                    () -> assertThat(알고리즘스터디.getParticipants().size()).isEqualTo(2),
-                    () -> assertThat(알고리즘스터디.getParticipants().contains(new Participant(장재우, 알고리즘스터디)))
-            );
+            softly.assertThat(알고리즘스터디.getParticipants().size()).isEqualTo(2);
+            softly.assertThat(알고리즘스터디.getParticipants().contains(new Participant(최규현, 알고리즘스터디)));
+            softly.assertThat(알고리즘스터디.getParticipants().contains(new Participant(장재우, 알고리즘스터디)));
         }
     }
 

--- a/backend/src/test/resources/sql/insert.sql
+++ b/backend/src/test/resources/sql/insert.sql
@@ -17,6 +17,11 @@ INSERT INTO notice (notice_id, create_date, modified_date, contents, delete_yn, 
 INSERT INTO notice (notice_id, create_date, modified_date, contents, delete_yn, pin_yn, title, study_id, user_id) VALUES (3, '2023-09-09 00:09:20.247088', '2023-09-09 00:10:34.784027', '상세내용3', 'N', 'N', '공지사항3', 1, 1);
 INSERT INTO notice (notice_id, create_date, modified_date, contents, delete_yn, pin_yn, title, study_id, user_id) VALUES (4, '2023-09-10 00:09:20.247088', '2023-09-10 00:10:34.784027', '상세내용4', 'N', 'N', '공지사항4', 1, 1);
 
+-- check_notice
+INSERT INTO check_notice (id, notice_id, user_id) VALUES (1, 4, 1);
+INSERT INTO check_notice (id, notice_id, user_id) VALUES (2, 4, 2);
+
+
 -- comment
 INSERT INTO comment (comment_id, create_date, modified_date, contents, delete_yn, notice_id, parent_comment_id, user_id) VALUES (1, '2023-09-08 21:08:38.757307', '2023-09-08 21:08:38.757307', '댓글1', 'N', 1, null, 1);
 INSERT INTO comment (comment_id, create_date, modified_date, contents, delete_yn, notice_id, parent_comment_id, user_id) VALUES (3, '2023-09-02 21:08:38.757307', '2023-09-02 21:08:38.757307', '대댓글1', 'N', 1, 1, 1);


### PR DESCRIPTION
스프링 내에서 지연 로딩 사용 시에 프록시 객체를 주입함.
관련해서 개념이 부족해서, 아예 지연 로딩을 사용하지 않거나 코드로 대충 막아놓은 부분이 있었는데 일괄 수정

---

> User 내 일대다 연관관계인 roles를 lazy로 하는 경우 발생하는 오류 해결
영속성 컨텍스트를 open&close 하는 OSIV는 default로 Interceptor에서 동작하지만, Filter에서 사용자 인증을 위해 Lazy 객체를 가져와야 함. 따라서 OSIV의 순서를 Filter로 옮기고 그 중에서도 가장 먼저 타게 순서를 정함

