### PR TITLE
[B] feat: 회원가입 시에 프로필 이미지 업로드 되도록 구현

### DIFF
--- a/backend/src/main/java/ssu/groupstudy/domain/auth/api/AuthApi.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/auth/api/AuthApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import ssu.groupstudy.domain.auth.dto.request.MessageRequest;
 import ssu.groupstudy.domain.auth.dto.request.PasswordResetRequest;
 import ssu.groupstudy.domain.auth.dto.request.VerifyRequest;
@@ -15,6 +16,7 @@ import ssu.groupstudy.global.dto.DataResponseDto;
 import ssu.groupstudy.global.dto.ResponseDto;
 
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/auth")
@@ -33,8 +35,8 @@ public class AuthApi {
 
     @Operation(summary = "회원가입")
     @PostMapping("/signUp")
-    public ResponseDto signUp(@Valid @RequestBody SignUpRequest dto) {
-        Long userId = authService.signUp(dto);
+    public ResponseDto signUp(@Valid @RequestPart("dto") SignUpRequest dto, @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) throws IOException {
+        Long userId = authService.signUp(dto, profileImage);
         return DataResponseDto.of("userId", userId);
     }
 

--- a/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/user/domain/User.java
@@ -58,16 +58,13 @@ public class User extends BaseEntity {
     private char deleteYn;
 
     @Builder
-    public User(String name, String nickname, String picture, String phoneModel, String phoneNumber, String password) {
+    public User(String name, String nickname, String phoneNumber, String password) {
         this.name = name;
         this.nickname = nickname;
-        this.picture = picture;
         this.phoneNumber = phoneNumber;
         this.password = password;
         this.activateDate = LocalDateTime.now();
-        this.phoneModel = phoneModel;
         this.deleteYn = 'N';
-        this.statusMessage = "";
     }
 
     @Override

--- a/backend/src/main/java/ssu/groupstudy/domain/user/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/user/dto/request/SignUpRequest.java
@@ -1,7 +1,6 @@
 package ssu.groupstudy.domain.user.dto.request;
 
 import lombok.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import ssu.groupstudy.domain.user.domain.User;
 
 import javax.validation.constraints.NotBlank;
@@ -16,21 +15,17 @@ public class SignUpRequest {
     private String name;
     @NotBlank(message = "닉네임을 입력하세요")
     private String nickname;
-    private String phoneModel;
-    private String picture;
     @NotBlank(message = "휴대폰번호를 입력하세요")
     private String phoneNumber;
     @NotBlank(message = "비밀번호를 입력하세요")
     private String password;
 
-    public User toEntity(PasswordEncoder passwordEncoder){
+    public User toEntity(String password){
         return User.builder()
                 .name(this.name)
                 .nickname(this.nickname)
-                .phoneModel(this.phoneModel)
-                .picture(this.picture)
                 .phoneNumber(this.phoneNumber)
-                .password(passwordEncoder.encode(this.password))
+                .password(password)
                 .build();
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/global/util/S3Utils.java
+++ b/backend/src/main/java/ssu/groupstudy/global/util/S3Utils.java
@@ -3,6 +3,7 @@ package ssu.groupstudy.global.util;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class S3Utils {
     private final AmazonS3 amazonS3;
 
@@ -21,6 +23,7 @@ public class S3Utils {
     private String imageBucket;
 
     public String uploadUserProfileImage(MultipartFile image, User user) throws IOException {
+        log.info("## uploadUserProfileImage ");
         ObjectMetadata metadata = createMetadataForFile(image);
         String imageName = generateImageName(S3Code.USER_IMAGE, user);
         amazonS3.putObject(imageBucket, imageName, image.getInputStream(), metadata);

--- a/backend/src/test/java/ssu/groupstudy/domain/common/ServiceTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/common/ServiceTest.java
@@ -6,8 +6,6 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 import ssu.groupstudy.domain.comment.domain.Comment;
 import ssu.groupstudy.domain.comment.dto.request.CreateCommentRequest;
@@ -93,24 +91,19 @@ public class ServiceTest {
                 .phoneNumber("rbgus200@naver.com")
                 .password("valid")
                 .nickname("규규")
-                .phoneModel("")
-                .picture("")
                 .build();
         장재우SignUpRequest = SignUpRequest.builder()
                 .name("장재우")
                 .phoneNumber("arkady@naver.com")
                 .password("password")
                 .nickname("킹적화")
-                .phoneModel("")
-                .picture("")
                 .build();
     }
 
     private void initUser() {
-        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-        최규현 = 최규현SignUpRequest.toEntity(passwordEncoder);
+        최규현 = 최규현SignUpRequest.toEntity("password");
         ReflectionTestUtils.setField(최규현, "userId", 1L);
-        장재우 = 장재우SignUpRequest.toEntity(passwordEncoder);
+        장재우 = 장재우SignUpRequest.toEntity("password");
         ReflectionTestUtils.setField(장재우, "userId", 2L);
     }
 

--- a/backend/src/test/java/ssu/groupstudy/domain/notice/api/NoticeApiTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/notice/api/NoticeApiTest.java
@@ -43,8 +43,6 @@ class NoticeApiTest extends ApiTest {
                 .name("최규현")
                 .phoneNumber("rbgus200@@naver.com")
                 .nickname("규규")
-                .phoneModel("")
-                .picture("")
                 .build();
     }
 

--- a/backend/src/test/java/ssu/groupstudy/domain/rule/api/RuleApiTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/rule/api/RuleApiTest.java
@@ -59,8 +59,6 @@ class RuleApiTest {
                 .name("최규현")
                 .phoneNumber("rbgus200@@naver.com")
                 .nickname("규규")
-                .phoneModel("")
-                .picture("")
                 .build();
     }
 

--- a/backend/src/test/java/ssu/groupstudy/domain/study/api/StudyApiTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/study/api/StudyApiTest.java
@@ -50,8 +50,6 @@ class StudyApiTest {
                 .name("최규현")
                 .phoneNumber("rbgus2002@naver.com")
                 .nickname("규규")
-                .phoneModel("")
-                .picture("")
                 .build();
     }
 

--- a/backend/src/test/java/ssu/groupstudy/domain/user/domain/UserTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/user/domain/UserTest.java
@@ -19,8 +19,6 @@ class UserTest {
         User user = User.builder()
                 .name("")
                 .nickname("")
-                .phoneModel("")
-                .picture("")
                 .phoneNumber("")
                 .build();
 


### PR DESCRIPTION
1. 기존 회원가입 dto 내에 picture 제거되었습니다.
2. 기존 회원가입 dto 내에 phoneModel이 제거되었습니다. 
3. 회원가입 시에 user의 phoneModel, statusMessage는 null값이 들어갑니다.
4. 회원가입 시에 프로필 이미지를 입력하지 않은 경우 picture은 null값이 들어갑니다.
5. body에 image가 추가되었습니다.
6. request body의 인자가 크게 'dto'와 'profileImage' 두가지 입니다. dto의 경우 반드시 contentType을 application/json으로 지정해주어야 합니다. 아래 사진 참고 (따라서 swagger에서 테스트가 불가능하여 postman으로 api 테스트 진행했습니다.)
<img width="1076" alt="image" src="https://github.com/rbgus2002/groupstudy/assets/62997391/528bbd5b-9bf2-4286-b0f7-414a782f285c">

7. profileImage는 사용자가 프로필 이미지를 업로드하지 않는 경우 body에서 제외하고 요청할 수 있습니다. (body에서 제외하고 요청하는 경우 null값입니다.)